### PR TITLE
Change swamp to multiply time countdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Converted worlds to be compatible with Webots R2023b. Erebus v24.0.0 must be run with Webots R2023b, download it [here](https://github.com/cyberbotics/webots/releases/tag/R2023b).
 - Reworked swamps
-  - Swamps no longer slow, instead multiplies the game's timer countdown rate by 2.0x.
+  - Swamps no longer slow, instead multiplies the game's timer countdown rate by 5.0x.
 - Reworked hazard/victim detection logic
   - Detection is now based on the nearest victim to the sent estimated score (previously, this was arbitrary if two victims were both within valid detection range)
   - The semi-circle detection area logic has been reworked. Previously this was calculated at fixed 90° intervals, corresponding to the 4 different wall angles a victim could face. However, this didn't work well for complex wall regions (curved or in room 4). The semi-circle detection area is now based on the surface normal of the hazard/victim, allowing for more accurate detection regions. See the diagram below for more details (for illustration purposes only):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 - Converted worlds to be compatible with Webots R2023b. Erebus v24.0.0 must be run with Webots R2023b, download it [here](https://github.com/cyberbotics/webots/releases/tag/R2023b).
+- Reworked swamps
+  - Swamps no longer slow, instead multiplies the game's timer countdown rate by 2.0x.
 - Reworked hazard/victim detection logic
   - Detection is now based on the nearest victim to the sent estimated score (previously, this was arbitrary if two victims were both within valid detection range)
   - The semi-circle detection area logic has been reworked. Previously this was calculated at fixed 90° intervals, corresponding to the 4 different wall angles a victim could face. However, this didn't work well for complex wall regions (curved or in room 4). The semi-circle detection area is now based on the surface normal of the hazard/victim, allowing for more accurate detection regions. See the diagram below for more details (for illustration purposes only):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,7 @@ As a quick summary: Stick to 80 character lines, detailed doc strings, type hint
 | Function/Method Parameters | `lower_with_under`    |                          |
 | Local Variables            | `lower_with_under`    |                          |
 
+For instances where a `type | None` type hint is required, prefer the syntax `Optional[type]`. 
 
 ### Note regarding Webots controllers
 

--- a/game/controllers/MainSupervisor/MainSupervisor.py
+++ b/game/controllers/MainSupervisor/MainSupervisor.py
@@ -97,6 +97,7 @@ class Erebus(Supervisor):
         self._real_time_elapsed: float = 0.0
         self._last_real_time: float = -1.0
         self._first_real_time: bool = True
+        self._time_muliplier: float = 1.0
         # Maximum time for a match
         self.max_time: int = 8 * 60
 
@@ -326,6 +327,14 @@ class Erebus(Supervisor):
             self.step(Erebus.TIME_STEP)
             if self.getTime() - first > sec:
                 break
+    
+    def set_time_multiplier(self, multiplier: float) -> None:
+        """Set time multiplier for game countdown timer
+
+        Args:
+            multiplier (float): Countdown time multiplier
+        """
+        self._time_muliplier = multiplier
             
     def _get_current_world(self) -> str:
         """Gets the current world name, with no file extension
@@ -887,6 +896,8 @@ class Erebus(Supervisor):
             self._last_real_time = time.time()
             # Get the time since the last frame
             frameTime = self.getTime() - self._last_time
+            # Scale frame time by countdown time multiplier (used for swamps)
+            frameTime *= self._time_muliplier
             # Add to the elapsed time
             self.time_elapsed += frameTime
             # Get the current time

--- a/game/controllers/MainSupervisor/Robot.py
+++ b/game/controllers/MainSupervisor/Robot.py
@@ -464,27 +464,23 @@ class Robot(ErebusObject):
             self.increase_score("Found checkpoint", 10, 
                                 multiplier=TileManager.ROOM_MULT[room_num])
 
-    def update_in_swamp(self, in_swamp: bool, max_velocity: float) -> None:
-        """Updates the robot's velocity if within a swamp.
+    def update_in_swamp(self, in_swamp: bool, default_multiplier: float) -> None:
+        """Updates the game's timer countdown multiplier when in a swamp.
 
         Args:
             in_swamp (bool): Whether the robot has entered a swamp
-            max_velocity (float): Max velocity multiplier to slow the robot by
+            default_multiplier (float): Default time multiplier
         """
         # Check if robot is in swamp
         if self.in_swamp != in_swamp:
             self.in_swamp = in_swamp
             if self.in_swamp:
-                # Cap the robot's velocity to 2
-                self.set_max_velocity(TileManager.SWAMP_SLOW_MULT)
-                # Reset physics
-                self._wb_node.resetPhysics()
+                # Update time multiplier 
+                self._erebus.set_time_multiplier(TileManager.SWAMP_TIME_MULT)
                 # Update history
                 self.history.enqueue("Entered swamp")
             else:
-                # If not in swamp, reset max velocity to default
-                self.set_max_velocity(max_velocity)
-                # Reset physics
-                self._wb_node.resetPhysics()
+                # Reset time multiplier
+                self._erebus.set_time_multiplier(default_multiplier)
                 # Update history
                 self.history.enqueue("Exited swamp,")

--- a/game/controllers/MainSupervisor/Tile.py
+++ b/game/controllers/MainSupervisor/Tile.py
@@ -129,7 +129,7 @@ class TileManager(ErebusObject):
     
     # Room multipliers
     ROOM_MULT: list[float] = [1, 1.25, 1.5, 2]
-    SWAMP_TIME_MULT: float = 2.0
+    SWAMP_TIME_MULT: float = 5.0
 
     def __init__(self, erebus: Erebus):
         """Creates a new TileManager object. Initialises start tile, checkpoint

--- a/game/controllers/MainSupervisor/Tile.py
+++ b/game/controllers/MainSupervisor/Tile.py
@@ -129,7 +129,7 @@ class TileManager(ErebusObject):
     
     # Room multipliers
     ROOM_MULT: list[float] = [1, 1.25, 1.5, 2]
-    SWAMP_SLOW_MULT: float = 0.32
+    SWAMP_TIME_MULT: float = 2.0
 
     def __init__(self, erebus: Erebus):
         """Creates a new TileManager object. Initialises start tile, checkpoint


### PR DESCRIPTION
Reworked swamps
- Swamps no longer slow, instead multiplies the game's timer countdown rate by 5.0x.