### PR TITLE
fix infinite point bug in main supervisor

### DIFF
--- a/game/controllers/MainSupervisor/MainSupervisor.py
+++ b/game/controllers/MainSupervisor/MainSupervisor.py
@@ -893,7 +893,7 @@ class Erebus(Supervisor):
             # If the time is up
             if ((self.time_elapsed >= self.max_time or
                  self._real_time_elapsed >= self._max_real_world_time) and
-                    self._last_frame != -1):
+                    self._last_frame != None):
                 self._add_map_multiplier()
                 self._robot_quit(True)
 


### PR DESCRIPTION
change the check in the map point bonus to None instead of -1 to prevent the check applying every update and thus granting infinite points