### PR TITLE
Fix mapping of centered signs

### DIFF
--- a/game/controllers/MainSupervisor/MainSupervisor.py
+++ b/game/controllers/MainSupervisor/MainSupervisor.py
@@ -140,7 +140,7 @@ class Erebus(Supervisor):
         self.robot_obj.reset_proto()
 
         # Calculate the solution arrays for the map layout
-        self._map_ans = MapAnswer(self)
+        self._map_ans = MapAnswer.from_supervisor(self)
         map_ans: Optional[list[list]] = self._map_ans.generateAnswer()
         if map_ans is None:
             raise Exception("Critical error: Could not generate answer matrix")

--- a/game/controllers/MainSupervisor/MapAnswer.py
+++ b/game/controllers/MainSupervisor/MapAnswer.py
@@ -109,10 +109,6 @@ class MapAnswer:
         self.victims = victims
         self.hazards = hazards
         
-        # TODO(Richo): I don't understand this. If the last node is not a TILE or START_TILE we just ignore it? When could that happen?
-        # if self.tileNodes.getMFNode(self.numberTiles - 1).getDef() != "TILE" and self.tileNodes.getMFNode(self.numberTiles - 1).getDef() != "START_TILE":
-        #     self.numberTiles -= 1
-        
         xPos = [t.xPos for t in tiles]
         zPos = [t.zPos for t in tiles]
         x_size = max(xPos) - min(xPos) + 1


### PR DESCRIPTION
This pull request fixes the issue with the MapAnswer solution placing victims/hazards signs in the wrong cell when they appear in the middle of the wall.

I added the following picture to explain the problem better:
![erebus_tile_center_bug](https://github.com/user-attachments/assets/43d50490-d95a-4331-bcfe-b6387fb6f728)

I made a few changes to the MapAnswer class in order to test the code independently from webots. Now the MapAnswer has its own representation of the world and we only need to interact with the Supervisor to gather this data at creation time. 

I used a bunch of different test files to make sure everything is working as intended. I didn't commit those changes here, but if you want to take a look: https://github.com/RichoM/erebus/tree/master/test
 