### PR TITLE
Fix mapping of signs in opposite sides of a wall

### DIFF
--- a/game/controllers/MainSupervisor/MapAnswer.py
+++ b/game/controllers/MainSupervisor/MapAnswer.py
@@ -423,8 +423,12 @@ class MapAnswer:
                     self.answerMatrix[z+3][x+3] = 'y'
             
             # Victims & Hazards
-            for victim in self.victims + self.hazards:
-                               
+            signs = self.victims + self.hazards
+
+            # Sort signs top to bottom, left to right
+            signs.sort(key=lambda s: (s.translation[2], s.translation[0]))
+
+            for victim in signs:                               
                 victimType = victim.type
                 if victimType == "harmed":
                     victimType = "H"


### PR DESCRIPTION
Currently, when two signs are placed on opposite sides of a wall the MapAnswer simply concatenates the letters in whichever order the signs happened to appear in the scene tree. With this change the order depends on the position of the signs in the map: top to bottom, and left to right.