### PR TITLE
Fixed encoding bug

### DIFF
--- a/game/controllers/MainSupervisor/DockerHelper.py
+++ b/game/controllers/MainSupervisor/DockerHelper.py
@@ -90,7 +90,7 @@ def run_docker_container(
         with subprocess.Popen(
             command,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, 
-            bufsize=1, universal_newlines=True, shell=False
+            bufsize=1, universal_newlines=True, shell=False, encoding="utf-8"
         ) as build_process:
             # Print output from build process
             if build_process.stdout:


### PR DESCRIPTION
This fixes an encoding bug when trying to pip install requirements inside the dockerfile.
It seems when pip downloads some packages it prints some characters to stdout that python fails to decode if the encoding is not specified.

"[EREBUS INFO] #12 [5/5] RUN pip3 install -r requirements.txt
[EREBUS INFO] #12 2.341 Collecting numpy==1.23.5
[EREBUS INFO] #12 2.481   Downloading numpy-1.23.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.1 MB)
[EREBUS ERROR] Error building project image - 'charmap' codec can't decode byte 0x81 in position 17: character maps to <undefined>"

![encoding_bug](https://github.com/user-attachments/assets/12e6dde8-8ba1-4506-875e-28f02005a896)

