### PR TITLE
Fixed mapping of rotated signs

### DIFF
--- a/game/controllers/MainSupervisor/MapAnswer.py
+++ b/game/controllers/MainSupervisor/MapAnswer.py
@@ -702,43 +702,6 @@ class Tile:
 
         return result
 
-# NOTE(Richo): Code taken from 
-# https://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToQuaternion/index.htm
-def angle_axis_to_quaternion(x, y, z, a):
-    w = math.cos(a/2)
-    x = x*math.sin(a/2)
-    y = y*math.sin(a/2)
-    z = z*math.sin(a/2)
-    return [w, x, y, z]
-
-# NOTE(Richo): Code taken from
-# https://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/
-def quaternion_to_euler(w, x, y, z):
-    sqw = w*w
-    sqx = x*x
-    sqy = y*y
-    sqz = z*z
-    unit = sqx + sqy + sqz + sqw # if normalised is one, otherwise is correction factor
-    test = x*y + z*w
-    # if test > 0.499*unit: # singularity at north pole
-    #     print("NORTH <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
-    #     heading = 2 * math.atan2(x,w)
-    #     attitude = math.pi/2
-    #     bank = 0
-    #     return heading, attitude, bank
-
-    # if test < -0.499*unit: # singularity at south pole
-    #     print("SOUTH <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
-    #     heading = -2 * math.atan2(x,w)
-    #     attitude = -math.pi/2
-    #     bank = 0
-    #     return heading, attitude, bank
-
-    heading = math.atan2(2*y*w-2*x*z , sqx - sqy - sqz + sqw)
-    attitude = math.asin(2*test/unit)
-    bank = math.atan2(2*x*w-2*y*z , -sqx + sqy - sqz + sqw)
-    return heading, attitude, bank
-
 class Sign:
     @classmethod
     def from_node(cls, node):
@@ -749,36 +712,30 @@ class Sign:
 
         r = node.getField("rotation").getSFRotation()
         rotation = [r[0], r[1], r[2], r[3]]
+
+        orientation = node.getOrientation()
         
-        return cls(type, translation, rotation)
+        return cls(type, translation, rotation, orientation)
     
     @classmethod
     def from_dict(cls, dict):
-        return cls(dict["type"], dict["translation"], dict["rotation"])
+        return cls(dict["type"], dict["translation"], dict["rotation"], dict["orientation"])
 
-    def __init__(self, type, translation, rotation):
+    def __init__(self, type, translation, rotation, orientation):
         self.type = type
         self.translation = translation
         self.rotation = rotation
-    
-    def get_rotation_quaternion(self):
-        x = self.rotation[0]
-        y = self.rotation[1]
-        z = self.rotation[2]
-        a = self.rotation[3]
-        return angle_axis_to_quaternion(x, y, z, a)
-    
-    def get_rotation_euler(self):
-        w, x, y, z = self.get_rotation_quaternion()
-        return quaternion_to_euler(w, x, y, z)
+        self.orientation = orientation
     
     def get_rotation_yaw(self):
-        yaw, _, _ = self.get_rotation_euler()
-        return yaw
+        x = self.orientation[2]
+        z = self.orientation[8]
+        return math.atan2(-x, -z)
     
     def to_dict(self):
         return {
             "type": self.type,
             "translation": self.translation,
-            "rotation": self.rotation
+            "rotation": self.rotation,
+            "orientation": self.orientation,
         }

--- a/game/controllers/MainSupervisor/Victim.py
+++ b/game/controllers/MainSupervisor/Victim.py
@@ -61,6 +61,8 @@ class VictimObject(ABC):
         
         self.wb_node: Node = node
 
+        self.orientation = node.getOrientation()
+
         self.score_worth: int = score
         self._victim_type: str = victim_type
         self.simple_victim_type: str = self.get_simple_type()
@@ -149,14 +151,7 @@ class VictimObject(ABC):
         Returns:
             npt.NDArray: Normalised surface normal vector
         """
-        # Angle of 0 (no rotation), e.g. [0,0,0,0], points upwards, therefore
-        # has surface normal of [0,0,-1]
-
-        # Rotate by rotation of victim
-        rot: npt.NDArray = rotate_2d_vector(np.array([0, -1]), 
-                                            -self.rotation[3])
-        # Convert back to 3d vector
-        return np.array([rot[0], 0, rot[1]])
+        return np.array([-self.orientation[2], 0, -self.orientation[8]])
 
     def _get_vec_to_robot(self, robot: Robot) -> npt.NDArray:
         """Get normalised direction vector from victim to robot


### PR DESCRIPTION
When a map includes rotated signs, the solution matrix generated by the supervisor was placing some signs incorrectly (case A), now the code takes the rotation into account and generates the correct matrix (case B).

![rotated_signs_bug](https://github.com/user-attachments/assets/a8c4f002-4884-4e39-a900-99b8b85ab8ac)
