### PR TITLE
Updated version number, year, and links to 2025

### DIFF
--- a/game/controllers/MainSupervisor/MainSupervisor.py
+++ b/game/controllers/MainSupervisor/MainSupervisor.py
@@ -61,7 +61,7 @@ class Erebus(Supervisor):
 
         # Version info
         self._stream = 24
-        self.version = "24.1.0"
+        self.version = "25.0.1"
 
         # Start controller uploader
         uploader: Thread = Thread(target=ControllerUploader.start, daemon=True)

--- a/game/plugins/robot_windows/MainSupervisorWindow/MainSupervisorWindow.html
+++ b/game/plugins/robot_windows/MainSupervisorWindow/MainSupervisorWindow.html
@@ -13,7 +13,7 @@
 				<div class="row center">
 					<div class="col-12">
 						<img src="robocup.png" style="max-width:100%;max-height:50px;"/>
-						<p><b>Erebus Rescue Simulator 2024</b></p>
+						<p><b>Erebus Rescue Simulator 2025</b></p>
 						<span id="versionInfo"></span><br>
 						<span id="newVersion"></span>
 					</div>
@@ -74,8 +74,8 @@
 					<div class="hidden_show">
 						<div class="col-12">
 							<span>Changelog <a href="https://github.com/robocup-junior/erebus/blob/master/CHANGELOG.md" target="_blank">link</a></span><br>
-							<span>World Generator <a href="https://osaka.rcj.cloud/service/editor/simulation/2024" target="_blank">link</a></span><br>
-							<span>Robot Customiser <a href="https://v24.robot.erebus.rcj.cloud/" target="_blank">link</a></span>
+							<span>World Generator <a href="https://osaka.rcj.cloud/service/editor/simulation/2025" target="_blank">link</a></span><br>
+							<span>Robot Customiser <a href="https://v25.robot.erebus.rcj.cloud/" target="_blank">link</a></span>
 						</div>
 						<hr>
 						<div class="col-2"></div>


### PR DESCRIPTION
It seems we forgot to update the version number and links when releasing v25.0.0