### PR TITLE
Add OpenCV import to MainSupervisor.py

### DIFF
--- a/game/controllers/MainSupervisor/MainSupervisor.py
+++ b/game/controllers/MainSupervisor/MainSupervisor.py
@@ -5,6 +5,7 @@ AutoInstall._import("cl", "termcolor")
 AutoInstall._import("req", "requests")
 AutoInstall._import("overrides", "overrides")
 AutoInstall._import("PIL", "PIL", "pillow")
+AutoInstall._import("cv2", "cv2", "opencv-python")
 
 import os
 import shutil


### PR DESCRIPTION
I have a fresh install of Python, so did not have cv2 installed globally. This missing import is preventing the installation instructions from working.
